### PR TITLE
Fix MyLasso, Add Case II

### DIFF
--- a/code2/code2.ipynb
+++ b/code2/code2.ipynb
@@ -568,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,20 +580,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "((506, 591), 506)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "X.shape, len(Y)"
    ]
@@ -618,17 +607,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  4%|▍         | 2/50 [01:46<42:39, 53.31s/it]"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "n_models = 5\n",
     "n_sims = 50\n",
@@ -639,7 +620,6 @@
     "                                                                                 pct_test=0.25)\n",
     "    lasso = LassoBase(X_train, y_train)\n",
     "    predictions = (\n",
-    "        mean_squared_error(y_test, full_model(X_train, y_train, X_test)),\n",
     "        mean_squared_error(y_test, ridge_regression(X_train_scale, y_train, X_test_scale)),\n",
     "        mean_squared_error(y_test, lasso.min(X_test)),\n",
     "        mean_squared_error(y_test, lasso.one_se(X_test)),\n",


### PR DESCRIPTION
* Fix bug with calculation of intercept row in MyLasso()
* Generalize MSPE calculation in Part II Case I so the code can be reused in Case II
* Add some introductory text for both Cases of Part II
* Start Part II Case II

The analysis of both cases is still missing.
It takes ~45 minutes to process Case II on my machine.