### PR TITLE
Minor changes to Part I and Part II

### DIFF
--- a/code3/code3.ipynb
+++ b/code3/code3.ipynb
@@ -222,7 +222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Part II\n",
+    "## Part II: Clustering time series\n",
+    "\n",
+    "In this exercise, we cluster time series data, comparing the results of clustering with and without natural cubic splines.\n",
     "\n"
    ]
   },
@@ -230,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following imports are specific to Part II"
+    "The following imports are specific to Part II."
    ]
   },
   {
@@ -448,7 +450,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Clustering using Matrix $\\textbf{B}$"
+    "### Clustering using Matrix $\\textbf{B}$\n",
+    "\n",
+    "Here we cluster by $\\textbf{B}$, the spline coefficients for each observation."
    ]
   },
   {
@@ -485,7 +489,8 @@
    "metadata": {},
    "source": [
     "### Clustering using Matrix $\\textbf{X}$\n",
-    "\n"
+    "\n",
+    "By comparison, we cluster by $\\textbf{X}$, the raw time series data. The centers are noticeably less smooth than the NCS-clustered centers from matrix $\\textbf{B}$."
    ]
   },
   {


### PR DESCRIPTION
Part 1: Removed function that wasn't used. I originally planned to calculate S_ii manually, but the prof says it is ok to use `loess_fit.outputs.diagonal` to get this matrix.

Part 2: Fix error of second matrix being labeled "B" when it is actually X. Elaborated on what was done.