### PR TITLE
Initial IBCF Implementation

### DIFF
--- a/project4/report.ipynb
+++ b/project4/report.ipynb
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "user_mov_df = user_mov_df.sub(user_mov_df.mean(axis=1, skipna=True), axis=0)\n"
+    "user_mov_df_norm = user_mov_df.sub(user_mov_df.mean(axis=1, skipna=True), axis=0)\n"
    ]
   },
   {
@@ -302,11 +302,10 @@
    "source": [
     "min_cardinality = 3\n",
     "\n",
-    "index = user_mov_df.columns\n",
-    "s = cosine_similarity(user_mov_df.to_numpy(), min_cardinality=min_cardinality)\n",
+    "s = cosine_similarity(user_mov_df_norm.to_numpy(), min_cardinality=min_cardinality)\n",
     "s = pd.DataFrame(data=s,\n",
-    "                 index=user_mov_df.columns,\n",
-    "                 columns=user_mov_df.columns)"
+    "                 index=user_mov_df_norm.columns,\n",
+    "                 columns=user_mov_df_norm.columns)"
    ]
   },
   {
@@ -337,7 +336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Filtering Most Similar Movies\n",
+    "### Filtering by Most Similar Movies\n",
     "\n",
     "Next, for each movie, we determine the 30 most similar movies and set all other movies to NA. This allows for a more compact $S$ matrix. For movies that have fewer than 30 similar movies, all available similar movies (i.e., non-`NA`) are kept."
    ]
@@ -374,6 +373,92 @@
    "outputs": [],
    "source": [
     "s.to_csv(\"similarity.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ICBF\n",
+    "\n",
+    "#### Implementation of ICBF\n",
+    "\n",
+    "We calculate IBCF for all non-rated movies and return the 10 highest recommendations.\n",
+    "\n",
+    "In the case of tie breaks, movies are recommended by `movieID` in descending order, so the highest `movieID` is included first, followed by the second-highest, etc.\n",
+    "\n",
+    "If fewer than 10 recommendations are calculated, we fill the missing recommendations with the highest-rated movies in the user's highest-rated genre. In the case of multiple highest-rated movies, we pick the genre of the lowest `movieID`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def myIBCF(s, newuser, num_recs=10):\n",
+    "\n",
+    "    recs = newuser.copy(deep=True)\n",
+    "    recs.iloc[:] = np.nan\n",
+    "\n",
+    "    i_in_w = ~np.isnan(newuser)\n",
+    "    # Compute IBCF for non-rated movies\n",
+    "    for l in np.arange(newuser.shape[0])[np.isnan(newuser)]:\n",
+    "        s_li = s.iloc[l, :]\n",
+    "        i_in_sl = ~np.isnan(s_li)\n",
+    "        col_mask = np.logical_and(i_in_sl, i_in_w)\n",
+    "        if s_li[col_mask].sum() == 0:\n",
+    "            continue\n",
+    "        recs.iloc[l] = (\n",
+    "            1 / (s_li[col_mask].sum())\n",
+    "            * np.dot(s_li[col_mask], newuser[col_mask])\n",
+    "        )\n",
+    "    recs = recs[~np.isnan(recs)]\n",
+    "    #print(f\"# ratings: {np.count_nonzero(~np.isnan(newuser))}\")\n",
+    "    #print(f\"   # recs: {recs.shape[0]}\")\n",
+    "    if recs.shape[0] >= num_recs:\n",
+    "        #print(recs.iloc[recs.argsort().iloc[-num_recs:]])\n",
+    "        recnames = recs.iloc[recs.argsort().iloc[-num_recs:]].index.tolist()\n",
+    "        return sorted(recnames, key=lambda x: int(x[1:]))\n",
+    "    else:\n",
+    "        additional_recs = num_recs - recs.shape[0]\n",
+    "        return recs.index.tolist()\n",
+    "        # TODO: need to find additional recs.\n",
+    "        # Top by highest-rated genre in newuser?\n",
+    "        # Remember to exclude movies have already been rated by the users.\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validation of `myIBCF`\n",
+    "\n",
+    "To validate our implementation of `myIBCF`, we show the top 10 recommendations for:\n",
+    "* User \"u1181\" from rating matrix $R$\n",
+    "* User \"u1351\" from rating matrix $R$\n",
+    "* A hypothetical user who rates movie “m1613” with 5 and movie “m1755” with 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hypothetical_user = user_mov_df.iloc[0, :].copy(deep=True)\n",
+    "hypothetical_user.iloc[:] = np.nan\n",
+    "hypothetical_user.loc[[\"m1613\", \"m1755\"]] = [5, 4]\n",
+    "\n",
+    "test_users = [\n",
+    "    (\"User u1181\", user_mov_df.loc[\"u1181\", :]),\n",
+    "    (\"User u1351\", user_mov_df.loc[\"u1351\", :]),\n",
+    "    (\"Hypothetical user\", hypothetical_user)\n",
+    "]\n",
+    "\n",
+    "for username, w in test_users:\n",
+    "    print(f\"\\n{username}\\n--{len(username)*'-'}\\n{myIBCF(s, w)}\")"
    ]
   }
  ],

--- a/project4/report.ipynb
+++ b/project4/report.ipynb
@@ -317,7 +317,9 @@
     "\n",
     "In order to validate our similarity matrix and our implementation of centered cosine similarity, we show the pairwise similarity values from the $S$ matrix for the following specified movies:\n",
     "\n",
-    "\"m1\", \"m10\", \"m100\", \"m1510\", \"m260\", \"m3212\""
+    "```m1, m10, m100, m1510, m260, m3212```\n",
+    "\n",
+    "We are validating our results against the values in [Campuswire post #861](https://campuswire.com/c/G06C55090/feed/861)"
    ]
   },
   {
@@ -327,8 +329,8 @@
    "outputs": [],
    "source": [
     "pd.set_option(\"display.precision\", 7)\n",
-    "test_movies = [\"m1\", \"m10\", \"m100\", \"m1510\", \"m260\", \"m3212\"]\n",
-    "s.loc[test_movies, test_movies]"
+    "specified_movies = [\"m1\", \"m10\", \"m100\", \"m1510\", \"m260\", \"m3212\"]\n",
+    "s.loc[specified_movies, specified_movies]"
    ]
   },
   {
@@ -391,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/project4/report.ipynb
+++ b/project4/report.ipynb
@@ -206,7 +206,11 @@
    "source": [
     "## System II: Recommendation Based on IBCF\n",
     "\n",
-    "### Similarity Matrix Construction"
+    "### Similarity Matrix Construction\n",
+    "\n",
+    "To construct the similarity matrix, we require user ratings for various items. The input rating matrix is $R_{a \\times i}$, where $a$ is the number of users who have reviewed one or more movie, and $i$ is the number of movies.\n",
+    "\n",
+    "In the case of our dataset, there are 6040 users and 3706 movies, so $R$ is of shape $6040 \\times 3706$."
    ]
   },
   {
@@ -216,14 +220,35 @@
    "outputs": [],
    "source": [
     "user_mov_df = pd.read_csv('Rmat.csv')\n",
-    "user_mov_df"
+    "user_mov_df.shape"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cosine similarity definition."
+    "### Normalization of Ratings Matrix\n",
+    "We normalize the rating matrix by subtracting the row means from each row, ignoring `NA` entries. This addresses the variation in each user's average rating."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_mov_df = user_mov_df.sub(user_mov_df.mean(axis=1, skipna=True), axis=0)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cosine Similarity\n",
+    "\n",
+    "We seek to compute the similarity between movies (items). We select centered cosine similarity as our measure of similarity. Having normalized our ratings matrix by each user's average rating, the next step is computation of similarity.\n",
+    "\n",
+    "Our implementation of the cosine similarity between items is described below."
    ]
   },
   {
@@ -235,10 +260,7 @@
     "import numpy as np\n",
     "from tqdm import tqdm\n",
     "\n",
-    "def cosine_similarity(x, min_cardinality=3):\n",
-    "    # Center by row mean\n",
-    "    x -= np.nanmean(x, axis=1).reshape(-1, 1)\n",
-    "    \n",
+    "def cosine_similarity(x, min_cardinality=3):    \n",
     "    # Prepare symmetric result matrix\n",
     "    s = np.empty((x.shape[1], x.shape[1]))\n",
     "    s[:] = np.nan\n",
@@ -267,7 +289,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Extract data from dataframe and reformat as symmetric matrix of movie similarities."
+    "We apply this function to our centered ratings matrix, producing a symmetric similarity matrix $S_{i \\times i}$.\n",
+    "\n",
+    "We extract and re-wrap the column indices to retain the movie IDs."
    ]
   },
   {
@@ -289,7 +313,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Filter similarity matrix to only include top 30 similar movies."
+    "#### Validation of Similarity Matrix Before Filtering\n",
+    "\n",
+    "In order to validate our similarity matrix and our implementation of centered cosine similarity, we show the pairwise similarity values from the $S$ matrix for the following specified movies:\n",
+    "\n",
+    "\"m1\", \"m10\", \"m100\", \"m1510\", \"m260\", \"m3212\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.set_option(\"display.precision\", 7)\n",
+    "test_movies = [\"m1\", \"m10\", \"m100\", \"m1510\", \"m260\", \"m3212\"]\n",
+    "s.loc[test_movies, test_movies]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filtering Most Similar Movies\n",
+    "\n",
+    "Next, for each movie, we determine the 30 most similar movies and set all other movies to NA. This allows for a more compact $S$ matrix. For movies that have fewer than 30 similar movies, all available similar movies (i.e., non-`NA`) are kept."
    ]
   },
   {
@@ -304,7 +352,8 @@
     "    row = s.iloc[i, :]\n",
     "    num_selected = min([(~np.isnan(row)).sum(), max_similar, len(row)])\n",
     "    # Find max allowed similarity with NaN vals\n",
-    "    max_sim = np.roll(np.sort(row)[::-1], -np.count_nonzero(np.isnan(row)))[num_selected - 1]\n",
+    "    max_sim = np.roll(np.sort(row)[::-1],\n",
+    "                      -np.count_nonzero(np.isnan(row)))[num_selected - 1]\n",
     "    na_mask = row < max_sim\n",
     "    s.iloc[i, na_mask] = np.nan"
    ]
@@ -313,7 +362,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write filtered similarity matrix to file."
+    "This filtered similarity matrix is written to file as `similarity.csv`."
    ]
   },
   {
@@ -342,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Moved normalization of ratings matrix out of `cosine_similarity` to its own code block to mirror instructions
* Add similarity matrix validation from #37 
* Provided initial implementation of `myIBCF`
* Validate `myIBCF` by getting recommendations for 3 users

`myIBCF` is not currently handling the case of calculating fewer than 10 recommendations. An easy solution could be to find the genre of the user's highest-rated movie and use our top recommendations to fetch the missing recommendations.